### PR TITLE
[Day19] 정답률 로직 처리, 가입 그룹별 문제 조회, 새로운 게시글 알림 추가

### DIFF
--- a/client/src/api/fetch.ts
+++ b/client/src/api/fetch.ts
@@ -120,7 +120,7 @@ const fetchApi = {
   getProblems: async (groupIdx?: number) => {
     const response = groupIdx
       ? await fetch(`/api/problems/${groupIdx}`)
-      : await fetch(`api/problems`);
+      : await fetch(`/api/problems`);
     const problems = await response.json();
     return problems;
   },

--- a/client/src/components/GroupPage/Problem/index.tsx
+++ b/client/src/components/GroupPage/Problem/index.tsx
@@ -27,6 +27,10 @@ const ProblemContainer = styled.div`
   p {
     margin: 0;
   }
+
+  &:first-child {
+    margin-top: 16px;
+  }
 `;
 
 const GroupTitle = styled.div`

--- a/client/src/components/GroupPage/Problem/index.tsx
+++ b/client/src/components/GroupPage/Problem/index.tsx
@@ -1,4 +1,5 @@
 import fetchApi from 'api/fetch';
+import useAlertModal from 'hooks/useAlertModal';
 import React from 'react';
 import { useRecoilState } from 'recoil';
 import { solvedProblemState } from 'recoil/store';
@@ -134,16 +135,17 @@ const Problem = ({
 }) => {
   const [solvedProblems, setSolvedProblems] =
     useRecoilState(solvedProblemState);
+  const showAlert = useAlertModal();
 
   const handleAnswer = (selected: boolean) => {
     if (problem.answer === selected) {
-      alert('정답입니다.');
+      showAlert('정답입니다.');
       if (!solvedProblems.includes(problem.idx)) {
         setSolvedProblems(solvedProblems.concat(problem.idx));
         fetchApi.insertSolvedProblem(problem.idx);
       }
     } else {
-      alert('오답입니다.');
+      showAlert('오답입니다.', palette.alert);
     }
   };
 

--- a/client/src/components/GroupPage/ProblemList/index.tsx
+++ b/client/src/components/GroupPage/ProblemList/index.tsx
@@ -7,7 +7,8 @@ import fetchApi from 'api/fetch';
 import { Problem } from '..';
 import { IProblem } from 'types/problem';
 import { Skeleton } from 'components/common';
-import { GroupNavState } from 'recoil/store';
+import { GroupNavState, myJoinedGroupState } from 'recoil/store';
+import palette from 'theme/palette';
 
 const ProblemListContainer = styled.div<{ navState: boolean }>`
   width: 680px;
@@ -18,9 +19,35 @@ const ProblemListContainer = styled.div<{ navState: boolean }>`
   display: ${(props) => (props.navState ? 'block' : 'none')};
 `;
 
+const BoxStyle = styled.div`
+  width: 680px;
+  min-width: 680px;
+  height: 180px;
+  border-radius: 8px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  box-shadow: rgba(0, 0, 0, 0.16) 0px 1px 5px;
+  margin-top: 16px;
+  background-color: ${palette.white};
+`;
+
+const NoJoinedGroupDatabase = styled(BoxStyle)`
+  &::after {
+    content: '그룹 정보를 조회하지 못했습니다';
+  }
+`;
+
+const NoAuthority = styled(BoxStyle)`
+  &::after {
+    content: '그룹 가입 후 이용해주세요';
+  }
+`;
+
 const ProblemList = ({ groupIdx }: { groupIdx: number }) => {
   const groupNavState = useRecoilValue(GroupNavState);
   const [problemList, setProblemList] = useState<IProblem[]>([]);
+  const myJoinedGroups = useRecoilValue(myJoinedGroupState);
   const [isFetching, setFetching] = useState<boolean>(true);
 
   const fetchProblems = async (groupIdx: number) => {
@@ -44,10 +71,18 @@ const ProblemList = ({ groupIdx }: { groupIdx: number }) => {
 
   return (
     <ProblemListContainer navState={groupNavState.problem}>
-      {problemList.map((problem) => (
-        <Problem key={problem.idx} problem={problem} />
-      ))}
-      {isFetching && getSkeletons(3)}
+      {!myJoinedGroups ? (
+        <NoJoinedGroupDatabase />
+      ) : !myJoinedGroups.includes(groupIdx) ? (
+        <NoAuthority />
+      ) : (
+        <>
+          {problemList.map((problem) => (
+            <Problem key={problem.idx} problem={problem} />
+          ))}
+          {isFetching && getSkeletons(3)}
+        </>
+      )}
     </ProblemListContainer>
   );
 };

--- a/client/src/components/GroupPage/ProblemList/index.tsx
+++ b/client/src/components/GroupPage/ProblemList/index.tsx
@@ -18,7 +18,7 @@ const ProblemListContainer = styled.div<{ navState: boolean }>`
   display: ${(props) => (props.navState ? 'block' : 'none')};
 `;
 
-const ProblemList = () => {
+const ProblemList = ({ groupIdx }: { groupIdx: number }) => {
   const groupNavState = useRecoilValue(GroupNavState);
   const [problemList, setProblemList] = useState<IProblem[]>([]);
   const [isFetching, setFetching] = useState<boolean>(true);
@@ -39,7 +39,7 @@ const ProblemList = () => {
   }, []);
 
   useEffect(() => {
-    fetchProblems(1);
+    fetchProblems(groupIdx);
   }, []);
 
   return (

--- a/client/src/components/GroupPage/ProblemList/index.tsx
+++ b/client/src/components/GroupPage/ProblemList/index.tsx
@@ -1,20 +1,25 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
+import { useRecoilValue } from 'recoil';
 
 import fetchApi from 'api/fetch';
+
 import { Problem } from '..';
 import { IProblem } from 'types/problem';
 import { Skeleton } from 'components/common';
+import { GroupNavState } from 'recoil/store';
 
-const ProblemListContainer = styled.div`
+const ProblemListContainer = styled.div<{ navState: boolean }>`
   width: 680px;
   min-width: 680px;
   position: relative;
   box-sizing: border-box;
   padding-bottom: 48px;
+  display: ${(props) => (props.navState ? 'block' : 'none')};
 `;
 
 const ProblemList = () => {
+  const groupNavState = useRecoilValue(GroupNavState);
   const [problemList, setProblemList] = useState<IProblem[]>([]);
   const [isFetching, setFetching] = useState<boolean>(true);
 
@@ -38,7 +43,7 @@ const ProblemList = () => {
   }, []);
 
   return (
-    <ProblemListContainer>
+    <ProblemListContainer navState={groupNavState.problem}>
       {problemList.map((problem) => (
         <Problem key={problem.idx} problem={problem} />
       ))}

--- a/client/src/components/HomePage/PostList.tsx
+++ b/client/src/components/HomePage/PostList.tsx
@@ -39,7 +39,7 @@ const PostList = () => {
     observerRef.current = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting && !isFetching && hasMore) {
-          const lastIdx = posts[posts.length - 1].idx;
+          const lastIdx = posts.length !== 0 ? posts[posts.length - 1].idx : -1;
           fetchPostsMore(lastIdx, 10);
         }
       },

--- a/client/src/components/HomePage/PostList.tsx
+++ b/client/src/components/HomePage/PostList.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
-import { useRecoilState } from 'recoil';
-import { postListStore } from 'recoil/store';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { postListStore, usersocketStates } from 'recoil/store';
 import styled, { css } from 'styled-components';
 
 import fetchApi from 'api/fetch';
@@ -25,12 +25,14 @@ const Observer = styled.div`
 `;
 
 const PostList = () => {
+  const socket = useRecoilValue(usersocketStates);
   const [posts, setPosts] = useRecoilState(postListStore);
   const [problems, setProblems] = useState([]);
   const [isFetching, setFetching] = useState<boolean>(true);
   const [hasMore, setHasMore] = useState<boolean>(true);
   const problemOrders = useRef<number[]>([]);
   const observerRef = useRef<IntersectionObserver>();
+  const addedPostRef = useRef<number>(0);
 
   const observer = (element: HTMLDivElement) => {
     if (isFetching) return;
@@ -86,6 +88,12 @@ const PostList = () => {
   useEffect(() => {
     setPosts([]);
     fetchInit();
+    socket.on('post_added', () => {
+      addedPostRef.current += 1;
+    });
+    return () => {
+      socket.off('post_added');
+    };
   }, []);
 
   const getNextProblem = (idx: number) => {

--- a/client/src/components/HomePage/PostWriterModal/index.tsx
+++ b/client/src/components/HomePage/PostWriterModal/index.tsx
@@ -9,7 +9,8 @@ import {
   postListStore,
   postModalDataStates,
   alertState,
-  uploadImgList
+  uploadImgList,
+  usersocketStates
 } from 'recoil/store';
 import fetchApi from 'api/fetch';
 import { PostAddData, PostUpdateData, PostData } from 'types/post';
@@ -99,6 +100,7 @@ const PostWriterModal = () => {
   const [postList, setPostList] = useRecoilState(postListStore);
   const [alertModal, setAlertModal] = useRecoilState(alertState);
   const imgList = useRecoilValue(uploadImgList);
+  const socket = useRecoilValue(usersocketStates);
   const closePostModal = useClosePostModal();
   const alertMessage = useAlertModal();
 
@@ -167,6 +169,9 @@ const PostWriterModal = () => {
               : post
           );
 
+      if (isEnrollMode()) {
+        socket.emit('post_added');
+      }
       alertSuccess();
       setPostList(newPostList);
       closePostModal();

--- a/client/src/components/common/InfoSideBar.tsx
+++ b/client/src/components/common/InfoSideBar.tsx
@@ -100,7 +100,6 @@ const InfoSideBar = () => {
       : Number(((solvedProblemCount / rate.problemCount) * 100).toFixed(1));
   }, [solvedProblemCount, rate.problemCount]);
 
-  // 현재 그룹에 추가로 가입된 경우에는 값이 변경되지 않음 (그룹 관리 recoil 생기면 들어갈듯)
   useEffect(() => {
     const solvedRate = getSolvedRate();
     setRate((prev) => ({ ...prev, solvedRate }));

--- a/client/src/components/common/InitUserData.tsx
+++ b/client/src/components/common/InitUserData.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 
 import fetchApi from 'api/fetch';
 
@@ -7,16 +7,18 @@ import {
   userDataStates,
   usersocketStates,
   postModalDataStates,
-  solvedProblemState
+  solvedProblemState,
+  myJoinedGroupState
 } from 'recoil/store';
 import { RouteComponentProps, useHistory } from 'react-router-dom';
 import { IProblem } from 'types/problem';
+import { IGroup } from 'types/group';
 
 const InitUserData = (/*{ history }: RouteComponentProps*/) => {
   const [userdata, setUserdata] = useRecoilState(userDataStates);
   const [postData, setPostData] = useRecoilState(postModalDataStates);
-  const [solvedProblems, setSolvedProblems] =
-    useRecoilState(solvedProblemState);
+  const setSolvedProblems = useSetRecoilState(solvedProblemState);
+  const setJoinedGroups = useSetRecoilState(myJoinedGroupState);
   //const socket = useRecoilValue(usersocketStates);
   const history = useHistory();
 
@@ -43,6 +45,10 @@ const InitUserData = (/*{ history }: RouteComponentProps*/) => {
         setSolvedProblems(
           data.BTMUserProblemuseridx.map((item: IProblem) => item.idx)
         );
+        setJoinedGroups(
+          data.BTMUserGroupuseridx.map((item: IGroup) => item.idx)
+        );
+
         //socket?.emit('name', data.nickname);
       }
     })();

--- a/client/src/components/common/NewPostAlert/Alert.tsx
+++ b/client/src/components/common/NewPostAlert/Alert.tsx
@@ -1,0 +1,63 @@
+import styled, { keyframes } from 'styled-components';
+import palette from 'theme/palette';
+
+const EnterAnimation = keyframes`
+  0% {
+    opacity: 0%;
+    height: 0;
+  }
+  100% {
+    opacity: 100%;
+    height: 36px;
+  }
+`;
+
+const AlertModalWrap = styled.div`
+  position: fixed;
+  left: 50%;
+  top: 84px;
+  padding-left: 24px;
+  padding-right: 24px;
+  height: 36px;
+  z-index: 7;
+  transform: translateX(-50%);
+  font-size: 14px;
+  cursor: pointer;
+
+  box-sizing: border-box;
+  border-radius: 16px;
+  background-color: ${palette.lightgray};
+  color: black;
+  box-shadow: rgba(0, 0, 0, 0.16) 0px 1px 5px;
+  animation: ${EnterAnimation} 0.75s ease-in-out;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const Alert = ({
+  count,
+  setCount
+}: {
+  count: number;
+  setCount: React.Dispatch<React.SetStateAction<number>>;
+}) => {
+  const getMessage = (count: number): string => {
+    if (count < 5) {
+      return `${count}개`;
+    }
+    if (count < 10) {
+      return '5개 이상';
+    }
+    if (count < 20) {
+      return '10개 이상';
+    } else return '20개 이상';
+  };
+
+  return (
+    <AlertModalWrap onClick={() => setCount(0)}>
+      {getMessage(count)}의 새로운 메세지
+    </AlertModalWrap>
+  );
+};

--- a/client/src/components/common/NewPostAlert/index.tsx
+++ b/client/src/components/common/NewPostAlert/index.tsx
@@ -1,0 +1,26 @@
+import React, { useEffect, useState } from 'react';
+import { useRecoilValue } from 'recoil';
+import { usersocketStates } from 'recoil/store';
+import { Alert } from './Alert';
+
+const NewPostAlert = () => {
+  const socket = useRecoilValue(usersocketStates);
+  const [newPostCount, setNewPostCount] = useState<number>(0);
+
+  useEffect(() => {
+    socket.on('post_added', () => {
+      setNewPostCount((prev) => prev + 1);
+    });
+    return () => {
+      socket.off('post_added');
+    };
+  });
+
+  return newPostCount > 0 ? (
+    <Alert count={newPostCount} setCount={setNewPostCount} />
+  ) : (
+    <></>
+  );
+};
+
+export default NewPostAlert;

--- a/client/src/components/common/index.tsx
+++ b/client/src/components/common/index.tsx
@@ -12,6 +12,7 @@ import InitUserData from 'components/common/InitUserData';
 import InitSocket from 'components/common/InitSocket';
 import AlertModal from 'components/common/AlertModal';
 import Skeleton from 'components/common/Skeleton';
+import NewPostAlert from 'components/common/NewPostAlert';
 
 export {
   AlarmSideBar,
@@ -28,5 +29,6 @@ export {
   InitUserData,
   InitSocket,
   AlertModal,
-  Skeleton
+  Skeleton,
+  NewPostAlert
 };

--- a/client/src/pages/GroupPage.tsx
+++ b/client/src/pages/GroupPage.tsx
@@ -68,7 +68,7 @@ const GroupPage: React.FC<RouteComponentProps<{ groupidx: string }>> = ({
         <img src={os} alt="그룹 이미지" />
         <GroupNavBar />
         <About />
-        <ProblemList />
+        <ProblemList groupIdx={Number(match.params.groupidx)} />
       </ContentsContainer>
       <SideBar isLeft={false}>
         <ChatSideBar />

--- a/client/src/recoil/store.ts
+++ b/client/src/recoil/store.ts
@@ -142,7 +142,8 @@ export const rateState = atom<SolvedRates>({
   key: 'rateState',
   default: {
     prevRate: 0,
-    solvedRate: 0
+    solvedRate: 0,
+    problemCount: 0
   }
 });
 

--- a/client/src/recoil/store.ts
+++ b/client/src/recoil/store.ts
@@ -147,9 +147,9 @@ export const rateState = atom<SolvedRates>({
   }
 });
 
-export const myJoinedGroupState = atom<number[]>({
+export const myJoinedGroupState = atom<number[] | null>({
   key: 'myJoinedGroup',
-  default: []
+  default: null
 });
 
 export const groupListState = atom<IGroup[]>({

--- a/client/src/recoil/store.ts
+++ b/client/src/recoil/store.ts
@@ -147,6 +147,11 @@ export const rateState = atom<SolvedRates>({
   }
 });
 
+export const myJoinedGroupState = atom<number[]>({
+  key: 'myJoinedGroup',
+  default: []
+});
+
 export const groupListState = atom<IGroup[]>({
   key: 'groupListState',
   default: []

--- a/client/src/types/user/index.tsx
+++ b/client/src/types/user/index.tsx
@@ -1,4 +1,5 @@
 export interface SolvedRates {
   prevRate: number;
   solvedRate: number;
+  problemCount: number;
 }

--- a/server/src/service/dbManager/user.ts
+++ b/server/src/service/dbManager/user.ts
@@ -2,7 +2,7 @@ import db from '../../models';
 
 const getUserData = async (username: string) => {
   const [user, created] = await db.models.User.findOrCreate({
-    include: db.models.Problem,
+    include: [db.models.Problem, db.models.Group],
     where: { nickname: username },
     defaults: { nickname: username },
     logging: false

--- a/server/src/sockets/socketIO.ts
+++ b/server/src/sockets/socketIO.ts
@@ -2,7 +2,7 @@ import dbManager from '../service/dbManager'; // 왜 절대경로 안되지
 import { Socket, Server } from 'socket.io';
 import { IUserSocket } from '../types/interface';
 
-const UserObj:IUserSocket = {};
+const UserObj: IUserSocket = {};
 
 const socketIO = (server: any) => {
   const io = new Server(server);
@@ -10,10 +10,13 @@ const socketIO = (server: any) => {
     // socket.on('name', (username: string) => {
     //   socket.name = username;
     // });
-    socket.on('login notify', async (userData:{socketId:string, userName: string}) => {
-      UserObj[userData.socketId] = userData.userName;
-      io.emit('get current users', UserObj);
-    });
+    socket.on(
+      'login notify',
+      async (userData: { socketId: string; userName: string }) => {
+        UserObj[userData.socketId] = userData.userName;
+        io.emit('get current users', UserObj);
+      }
+    );
 
     socket.on('send chat initial', async (receivedData) => {
       const { sender, receiver } = receivedData;
@@ -43,6 +46,10 @@ const socketIO = (server: any) => {
           msg: msg
         });
       }
+    });
+
+    socket.on('post_added', () => {
+      socket.broadcast.emit('post_added');
     });
 
     socket.on('disconnect', () => {


### PR DESCRIPTION
## 관련 이슈
- #14 
- #26 

## 개요
- 문제 정답률 표현 실 데이터 통신하여 구현
- 그룹 문제 문제탭에서 보여지도록 분리
- 새로운 게시글 소켓 알람 처리

## 작업사항
- 정답률 처리 (실 데이터 이용)
- 그룹에 속한 사용자만 문제 볼 수 있도록 변경
- 정/오답 표시 alert 수정
- 새로운 게시글 있을경우 상단 alert 메세지 표시
