### PR TITLE
[리팩토링] 리렌더링 일부 개선

### DIFF
--- a/client/src/api/fetch/posts.ts
+++ b/client/src/api/fetch/posts.ts
@@ -4,7 +4,7 @@ const getPosts = async (
   signal: AbortSignal | null = null,
   option: Partial<PostRequestOptions> = {}
 ): Promise<PostData[]> => {
-  const { lastIdx = -1, count = 500, username } = option;
+  const { lastIdx = -1, count = 10, username } = option;
   const response = username
     ? await fetch(`/api/posts?username=${username}&lastIdx=${lastIdx}&count=${count}`, { signal })
     : await fetch(`/api/posts?lastIdx=${lastIdx}&count=${count}`, { signal });

--- a/client/src/api/fetch/posts.ts
+++ b/client/src/api/fetch/posts.ts
@@ -1,26 +1,16 @@
-import {
-  PostData,
-  PostAddData,
-  PostUpdateData,
-  PostRequestOptions
-} from 'types/post';
+import { PostData, PostAddData, PostUpdateData, PostRequestOptions } from 'types/post';
 
 const getPosts = async (
   signal: AbortSignal | null = null,
   option: Partial<PostRequestOptions> = {}
 ): Promise<PostData[]> => {
-  const { lastIdx = -1, count = 10, username } = option;
+  const { lastIdx = -1, count = 500, username } = option;
   const response = username
-    ? await fetch(
-        `/api/posts?username=${username}&lastIdx=${lastIdx}&count=${count}`,
-        { signal }
-      )
+    ? await fetch(`/api/posts?username=${username}&lastIdx=${lastIdx}&count=${count}`, { signal })
     : await fetch(`/api/posts?lastIdx=${lastIdx}&count=${count}`, { signal });
   const getPostsList = await response.json();
   return getPostsList.map((cur: any) =>
-    cur.BTMLikepostidx.length === 0
-      ? { ...cur, likeFlag: false }
-      : { ...cur, likeFlag: true }
+    cur.BTMLikepostidx.length === 0 ? { ...cur, likeFlag: false } : { ...cur, likeFlag: true }
   );
 };
 

--- a/client/src/components/HomePage/Post/Header.tsx
+++ b/client/src/components/HomePage/Post/Header.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import styled from 'styled-components';
 
 import { IconPublic, IconPrivate } from 'images/icons';

--- a/client/src/components/HomePage/Post/index.tsx
+++ b/client/src/components/HomePage/Post/index.tsx
@@ -1,10 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { MdMoreHoriz } from 'react-icons/md';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilValue } from 'recoil';
 
 import { usersocketStates } from 'recoil/socket';
-import { modalStateStore } from 'recoil/common';
 import { userDataStates } from 'recoil/user';
 
 import { LikeIcon, CommentIcon } from 'images/icons';
@@ -111,12 +110,12 @@ const Divider = styled.div`
 `;
 
 const Post = ({ post, isProfile = false }: { post: PostData; isProfile?: boolean }) => {
-  const [modalState, setModalState] = useRecoilState(modalStateStore);
   const { idx: myIdx } = useRecoilValue(userDataStates);
   const [likeFlag, setLikeFlag] = useState<boolean>(false);
   const [likeNum, setLikeNum] = useState<number>(0);
   const [commentFlag, setCommentFlag] = useState<boolean>(false);
   const [commentsNum, setCommentsNum] = useState<number>(post.commentnum);
+  const [isModalOpen, setModalOpen] = useState<boolean>(false);
   const socket = useRecoilValue(usersocketStates);
 
   const { idx: postIdx, secret, createdAt, contents, picture1, picture2, picture3, BTUseruseridx } = post;
@@ -148,18 +147,11 @@ const Post = ({ post, isProfile = false }: { post: PostData; isProfile?: boolean
   return (
     <PostContainer>
       {postUserIdx === myIdx && (
-        <IconHover
-          onClick={() =>
-            setModalState({
-              ...modalState,
-              post: { ...modalState.post, index: postIdx }
-            })
-          }
-        >
+        <IconHover onClick={() => setModalOpen(true)}>
           <MdMoreHoriz />
         </IconHover>
       )}
-      {modalState.post.index === postIdx && <OptionModal post={post} />}
+      {isModalOpen && <OptionModal post={post} setModalOpen={setModalOpen} />}
       <Header nickname={nickname} profile={profile} createdAt={createdAt} secret={secret} />
       <Body postBody={{ contents, picture1, picture2, picture3 }} isProfile={isProfile} />
       <Footer

--- a/client/src/components/HomePage/PostList/index.tsx
+++ b/client/src/components/HomePage/PostList/index.tsx
@@ -83,7 +83,7 @@ const PostList = () => {
         lastIdx,
         count
       });
-      if (result.length < count) {
+      if (result.length < count || posts.length + result.length >= 300) {
         setHasMore(false);
       }
       setPosts((prev) => prev.concat(result));

--- a/client/src/components/HomePage/PostWriter/index.tsx
+++ b/client/src/components/HomePage/PostWriter/index.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import styled from 'styled-components';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilValue } from 'recoil';
 
-import { modalStateStore } from 'recoil/common';
 import { userDataStates } from 'recoil/user';
+import useModalHandler from 'hooks/useModalHandler';
+import { ModalHandler } from 'types/common';
 
 import { iconPhoto } from 'images/icons';
 
@@ -94,21 +95,15 @@ const StyledBtn = styled.div`
 `;
 
 const PostWriter = () => {
-  const [modalState, setModalState] = useRecoilState(modalStateStore);
+  const handleModal = useModalHandler();
   const userdata = useRecoilValue(userDataStates);
 
   const postWriterModalOn = (e: React.MouseEvent<HTMLDivElement>) => {
-    setModalState({
-      ...modalState,
-      post: { ...modalState.post, writer: true }
-    });
+    handleModal(ModalHandler.OPEN_POST_WRITER);
   };
 
   const withImgUploadModalOn = (e: React.MouseEvent<HTMLDivElement>) => {
-    setModalState({
-      ...modalState,
-      post: { ...modalState.post, writer: true, inPhoto: true }
-    });
+    handleModal(ModalHandler.OPEN_IMAGE_UPLOADER);
   };
 
   return (

--- a/client/src/components/HomePage/PostWriterModal/AddContentsBar.tsx
+++ b/client/src/components/HomePage/PostWriterModal/AddContentsBar.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
-import { useRecoilState } from 'recoil';
+import { useRecoilValue } from 'recoil';
 
 import { modalStateStore } from 'recoil/common';
 import { iconPhoto } from 'images/icons';
+import useModalHandler from 'hooks/useModalHandler';
+import { ModalHandler } from 'types/common';
 
 const AddContentsBarWrap = styled.div`
   width: 95%;
@@ -54,13 +56,11 @@ const ContentsBtn = styled.div<{ modalState: boolean }>`
 `;
 
 const AddContentsBar = () => {
-  const [modalState, setModalState] = useRecoilState(modalStateStore);
+  const modalState = useRecoilValue(modalStateStore);
+  const handleModal = useModalHandler();
 
   const imgUploadModalToggle = (e: React.MouseEvent<HTMLDivElement>) => {
-    setModalState({
-      ...modalState,
-      post: { ...modalState.post, inPhoto: !modalState.post.inPhoto }
-    });
+    handleModal(ModalHandler.TOGGLE_IMAGE_UPLOADER);
   };
 
   return (

--- a/client/src/components/HomePage/PostWriterModal/ImgUploadModal.tsx
+++ b/client/src/components/HomePage/PostWriterModal/ImgUploadModal.tsx
@@ -1,6 +1,6 @@
 import React, { BaseSyntheticEvent, useEffect, useRef } from 'react';
 import styled, { keyframes } from 'styled-components';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { IoClose } from 'react-icons/io5';
 import { FiUpload } from 'react-icons/fi';
 
@@ -11,6 +11,8 @@ import { isImgUploadingState, postModalDataStates } from 'recoil/post';
 import fetchApi from 'api/fetch';
 import style from 'theme/style';
 import useAlertModal from 'hooks/useAlertModal';
+import useModalHandler from 'hooks/useModalHandler';
+import { ModalHandler } from 'types/common';
 
 const ModalAnimation = keyframes`
   0% {
@@ -187,12 +189,13 @@ const CloseOneImg = styled.div<{ imgsrc: string | undefined }>`
 `;
 
 const ImgUploadModal = () => {
-  const [modalState, setModalState] = useRecoilState(modalStateStore);
-  const [postData, setPostData] = useRecoilState(postModalDataStates);
+  const modalState = useRecoilValue(modalStateStore);
+  const postData = useRecoilValue(postModalDataStates);
   const [isImgUploading, setIsImgUploading] = useRecoilState(isImgUploadingState);
   const [imageViewerState, setImageViewerState] = useRecoilState(ivState);
   const [imgList, setImgList] = useRecoilState(uploadImgList);
   const alertMessage = useAlertModal();
+  const handleModal = useModalHandler();
 
   const inputfile = useRef() as React.MutableRefObject<HTMLInputElement>;
   const imgUploadWrapRef = useRef() as React.MutableRefObject<HTMLInputElement>;
@@ -201,10 +204,7 @@ const ImgUploadModal = () => {
 
   const imgUploadModalOff = (e: React.MouseEvent<HTMLDivElement>) => {
     e.stopPropagation();
-    setModalState({
-      ...modalState,
-      post: { ...modalState.post, inPhoto: false }
-    });
+    handleModal(ModalHandler.TOGGLE_IMAGE_UPLOADER);
   };
 
   const openFileModal = (e: React.MouseEvent<HTMLDivElement>) => {

--- a/client/src/components/HomePage/PostWriterModal/ModalTitle.tsx
+++ b/client/src/components/HomePage/PostWriterModal/ModalTitle.tsx
@@ -3,8 +3,9 @@ import { useRecoilValue } from 'recoil';
 import { IoClose } from 'react-icons/io5';
 
 import { modalStateStore } from 'recoil/common';
-
-import useClosePostModal from 'hooks/useClosePostModal';
+import useModalHandler from 'hooks/useModalHandler';
+import useResetPostModal from 'hooks/useResetPostModal';
+import { ModalHandler } from 'types/common';
 
 const ModalTitleWrap = styled.div`
   width: 100%;
@@ -49,12 +50,18 @@ const CloseBtn = styled.div`
 `;
 const ModalTitle = () => {
   const modalState = useRecoilValue(modalStateStore);
-  const closeModal = useClosePostModal();
+  const handleModal = useModalHandler();
+  const resetPostModalData = useResetPostModal();
 
   return (
     <ModalTitleWrap>
       <div>{modalState.post.isEnroll ? '게시물 만들기' : '게시물 수정하기'}</div>
-      <CloseBtn onClick={() => closeModal()}>
+      <CloseBtn
+        onClick={() => {
+          handleModal(ModalHandler.CLOSE_ALL);
+          resetPostModalData();
+        }}
+      >
         <IoClose size="28px" />
       </CloseBtn>
     </ModalTitleWrap>

--- a/client/src/components/HomePage/PostWriterModal/index.tsx
+++ b/client/src/components/HomePage/PostWriterModal/index.tsx
@@ -1,14 +1,15 @@
-import React from 'react';
 import styled, { keyframes } from 'styled-components';
 import { useRecoilState, useRecoilValue } from 'recoil';
 
 import { usersocketStates } from 'recoil/socket';
 import { modalStateStore } from 'recoil/common';
 import { isImgUploadingState, postListStore, postModalDataStates, uploadImgList } from 'recoil/post';
+import useModalHandler from 'hooks/useModalHandler';
+import useResetPostModal from 'hooks/useResetPostModal';
+import { ModalHandler } from 'types/common';
 
 import fetchApi from 'api/fetch';
 import { PostAddData, PostUpdateData, PostData } from 'types/post';
-import useClosePostModal from 'hooks/useClosePostModal';
 import useAlertModal from 'hooks/useAlertModal';
 
 import ModalTitle from 'components/HomePage/PostWriterModal/ModalTitle';
@@ -98,7 +99,8 @@ const PostWriterModal = () => {
   const [postList, setPostList] = useRecoilState(postListStore);
   const imgList = useRecoilValue(uploadImgList);
   const socket = useRecoilValue(usersocketStates);
-  const closePostModal = useClosePostModal();
+  const handleModal = useModalHandler();
+  const resetPostModalData = useResetPostModal();
   const alertMessage = useAlertModal();
 
   /**
@@ -155,19 +157,20 @@ const PostWriterModal = () => {
       }
       alertSuccess();
       setPostList(newPostList);
-      closePostModal();
+      closeModal();
     } else {
       alertFail();
     }
   };
 
-  const modalClose = (e: React.MouseEvent) => {
-    closePostModal();
+  const closeModal = () => {
+    handleModal(ModalHandler.CLOSE_ALL);
+    resetPostModalData();
   };
 
   return (
     <>
-      <PostWriterModalOverlay modalState={modalState.post.writer} onClick={modalClose} />
+      <PostWriterModalOverlay modalState={modalState.post.writer} onClick={closeModal} />
       <PostWriterModalInner modalState={modalState.post.writer} className="no-drag">
         <ModalTitle />
         <Line />

--- a/client/src/components/ProfilePage/PostList/index.tsx
+++ b/client/src/components/ProfilePage/PostList/index.tsx
@@ -76,7 +76,7 @@ const PostList = () => {
         count,
         username: nickname
       });
-      if (result.length < count) {
+      if (result.length < count || posts.length + result.length >= 300) {
         setHasMore(false);
       }
       setPosts((prev) => prev.concat(result));

--- a/client/src/components/ProfilePage/ProfileBar/ProfileEdit.tsx
+++ b/client/src/components/ProfilePage/ProfileBar/ProfileEdit.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilValue } from 'recoil';
 
-import { modalStateStore } from 'recoil/common';
 import { userDataStates, profileState } from 'recoil/user';
-
 import style from 'theme/style';
+import useModalHandler from 'hooks/useModalHandler';
+import { ModalHandler } from 'types/common';
 
 const ProfileEditWrap = styled.div<{ myProfile: boolean }>`
   display: ${(props) => (props.myProfile ? 'flex' : 'none')};
@@ -38,13 +38,13 @@ const ProfileEditBtn = styled.div`
 `;
 
 const ProfileEdit = () => {
-  const [modalState, setModalState] = useRecoilState(modalStateStore);
   const userData = useRecoilValue(userDataStates);
   const profileData = useRecoilValue(profileState);
   const [myProfile, setMyProfile] = useState<boolean>(false);
+  const handleModal = useModalHandler();
 
   const toggleModalHandler = (e: React.MouseEvent) => {
-    setModalState({ ...modalState, editProfile: !modalState.editProfile });
+    handleModal(ModalHandler.TOGGLE_EDIT_PROFILE);
   };
 
   useEffect(() => {

--- a/client/src/components/ProfilePage/ProfileEditModal/index.tsx
+++ b/client/src/components/ProfilePage/ProfileEditModal/index.tsx
@@ -1,9 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import styled, { keyframes } from 'styled-components';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 
 import { modalStateStore } from 'recoil/common';
 import { profileState } from 'recoil/user';
+import useModalHandler from 'hooks/useModalHandler';
+import { ModalHandler } from 'types/common';
 
 import style from 'theme/style';
 import fetchApi from 'api/fetch';
@@ -96,8 +98,9 @@ const StyledBtn = styled.div<{ saveBtn: boolean }>`
 `;
 
 const ProfileEditModal = () => {
+  const modalState = useRecoilValue(modalStateStore);
+  const handleModal = useModalHandler();
   const [profileData, setProfileData] = useRecoilState(profileState);
-  const [modalState, setModalState] = useRecoilState(modalStateStore);
   const [bio, setBio] = useState<string>('');
   const alertMessage = useAlertModal();
 
@@ -118,11 +121,11 @@ const ProfileEditModal = () => {
       return alertMessage('내용을 입력하세요.', true);
     }
     setProfileData({ ...profileData, bio: bio.trim() });
-    setModalState({ ...modalState, editProfile: false });
+    handleModal(ModalHandler.CLOSE_ALL);
   };
 
   const cancelBtnHandler = (e: React.MouseEvent) => {
-    setModalState({ ...modalState, editProfile: false });
+    handleModal(ModalHandler.CLOSE_ALL);
   };
 
   const bioLengthCheck = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/client/src/components/common/Gnb/UserCard.tsx
+++ b/client/src/components/common/Gnb/UserCard.tsx
@@ -1,11 +1,10 @@
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
-import { useRecoilState } from 'recoil';
-
-import { modalStateStore } from 'recoil/common';
 
 import { SearchedUser } from 'types/GNB';
 import useResetProfile from 'hooks/useResetProfile';
+import useModalHandler from 'hooks/useModalHandler';
+import { ModalHandler } from 'types/common';
 
 import { ProfilePhoto } from 'components/common';
 
@@ -35,12 +34,12 @@ const NavLink = styled(Link)`
 `;
 
 const UserCard = ({ user }: { user: SearchedUser }) => {
-  const [modalState, setModalState] = useRecoilState(modalStateStore);
+  const handleModal = useModalHandler();
   const resetProfile = useResetProfile();
 
   const handleCardClick = () => {
     resetProfile(user.nickname);
-    setModalState({ ...modalState, searchUser: false });
+    handleModal(ModalHandler.CLOSE_ALL);
   };
 
   return (

--- a/client/src/components/common/Gnb/UserSearchBar.tsx
+++ b/client/src/components/common/Gnb/UserSearchBar.tsx
@@ -1,12 +1,11 @@
 import { useState, useRef, useEffect } from 'react';
 import styled, { css, keyframes } from 'styled-components';
-import { useRecoilState } from 'recoil';
-
-import { modalStateStore } from 'recoil/common';
 
 import fetchApi from 'api/fetch';
 import { SearchedUser } from 'types/GNB';
 import { IconSearch } from 'images/icons';
+import useModalHandler from 'hooks/useModalHandler';
+import { ModalHandler } from 'types/common';
 
 const ExtendSearchBarAnimation = keyframes`
   0% {
@@ -75,7 +74,7 @@ const UserSearchBar = ({
   >;
 }) => {
   const [input, setInput] = useState('');
-  const [modalState, setModalState] = useRecoilState(modalStateStore);
+  const handleModal = useModalHandler();
   const inputBox = useRef<HTMLInputElement>(null);
 
   const onChangeInput = (e: any) => {
@@ -102,7 +101,7 @@ const UserSearchBar = ({
   }, [input]);
 
   return (
-    <UserSearchBarContainer isFake={isFake} onClick={() => setModalState({ ...modalState, searchUser: true })}>
+    <UserSearchBarContainer isFake={isFake} onClick={() => handleModal(ModalHandler.OPEN_USER_SEARCH)}>
       {isFake && <IconSearch />}
       {isFake ? (
         <input type="text" placeholder="사용자 검색" readOnly />

--- a/client/src/components/common/Gnb/UserSearchModal.tsx
+++ b/client/src/components/common/Gnb/UserSearchModal.tsx
@@ -1,11 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
-import { useRecoilState } from 'recoil';
 import { MdArrowBack } from 'react-icons/md';
 
-import { modalStateStore } from 'recoil/common';
-
 import { SearchedUser } from 'types/GNB';
+import { ModalHandler } from 'types/common';
+import useModalHandler from 'hooks/useModalHandler';
 
 import { UserCard } from 'components/common';
 import UserSearchBar from 'components/common/Gnb/UserSearchBar';
@@ -80,7 +79,7 @@ const SearchModalBody = styled.div`
 `;
 
 const UserSearchModal = () => {
-  const [modalState, setModalState] = useRecoilState(modalStateStore);
+  const handleModal = useModalHandler();
   const [searchResults, setSearchResults] = useState<{
     isProgress: boolean;
     users: SearchedUser[];
@@ -92,7 +91,7 @@ const UserSearchModal = () => {
     if (!force && modal.current?.contains(e.target)) {
       return;
     }
-    setModalState({ ...modalState, searchUser: false });
+    handleModal(ModalHandler.CLOSE_ALL);
   };
 
   useEffect(() => {

--- a/client/src/components/common/ProfilePhoto/index.tsx
+++ b/client/src/components/common/ProfilePhoto/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -27,7 +27,7 @@ const StyledProfilePhoto = styled.img<{ size?: string }>`
 `;
 
 const ProfilePhoto = ({ userName, size }: ProfilePhotoProps) => {
-  const profileImgURL = `https://github.com/${userName}.png`;
+  const profileImgURL = useMemo(() => `https://github.com/${userName}.png`, [userName]);
   return (
     <StyledProfilePhoto
       src={userName !== '' ? profileImgURL : defaultProfile}
@@ -52,5 +52,4 @@ const ClickableProfilePhoto = ({ userName, size }: ProfilePhotoProps) => {
     </ClickableProfilePhotoWrap>
   );
 };
-
 export { ProfilePhoto, ClickableProfilePhoto };

--- a/client/src/hooks/useModalHandler.tsx
+++ b/client/src/hooks/useModalHandler.tsx
@@ -1,0 +1,46 @@
+import { useResetRecoilState, useSetRecoilState } from 'recoil';
+import { modalStateStore } from 'recoil/common';
+import { ModalHandler, ModalHandlerOptions } from 'types/common';
+
+const useModalHandler = () => {
+  const setModalState = useSetRecoilState(modalStateStore);
+  const resetModal = useResetRecoilState(modalStateStore);
+
+  return (type: ModalHandler, options?: ModalHandlerOptions) => {
+    switch (type) {
+      case ModalHandler.OPEN_POST_WRITER: {
+        resetModal();
+        setModalState((prev) => ({
+          ...prev,
+          post: { writer: true, inPhoto: false, isEnroll: options?.post?.isEnroll ?? true }
+        }));
+        break;
+      }
+      case ModalHandler.OPEN_IMAGE_UPLOADER: {
+        setModalState((prev) => ({
+          ...prev,
+          post: { writer: true, inPhoto: true, isEnroll: options?.post?.isEnroll ?? true }
+        }));
+        break;
+      }
+      case ModalHandler.OPEN_USER_SEARCH: {
+        setModalState((prev) => ({ ...prev, searchUser: true }));
+        break;
+      }
+      case ModalHandler.TOGGLE_EDIT_PROFILE: {
+        setModalState((prev) => ({ ...prev, editProfile: !prev.editProfile }));
+        break;
+      }
+      case ModalHandler.TOGGLE_IMAGE_UPLOADER: {
+        setModalState((prev) => ({ ...prev, post: { ...prev.post, inPhoto: !prev.post.inPhoto } }));
+        break;
+      }
+      case ModalHandler.CLOSE_ALL: {
+        resetModal();
+        break;
+      }
+    }
+  };
+};
+
+export default useModalHandler;

--- a/client/src/hooks/useResetPostModal.tsx
+++ b/client/src/hooks/useResetPostModal.tsx
@@ -1,16 +1,12 @@
 import { useRecoilState, useResetRecoilState } from 'recoil';
-
-import { modalStateStore } from 'recoil/common';
 import { isImgUploadingState, postModalDataStates, uploadImgList } from 'recoil/post';
 
-const useClosePostModal = () => {
-  const resetModal = useResetRecoilState(modalStateStore);
+const useResetPostModal = () => {
   const resetImgList = useResetRecoilState(uploadImgList);
   const resetImgUploading = useResetRecoilState(isImgUploadingState);
   const [postData, setPostData] = useRecoilState(postModalDataStates);
 
   return () => {
-    resetModal();
     resetImgList();
     resetImgUploading();
     setPostData({
@@ -29,4 +25,4 @@ const useClosePostModal = () => {
   };
 };
 
-export default useClosePostModal;
+export default useResetPostModal;

--- a/client/src/hooks/useResetProfile.tsx
+++ b/client/src/hooks/useResetProfile.tsx
@@ -1,22 +1,18 @@
-import { useRecoilState, useResetRecoilState, useSetRecoilState } from 'recoil';
+import { useResetRecoilState, useSetRecoilState } from 'recoil';
 
-import { modalStateStore } from 'recoil/common';
 import { profileState } from 'recoil/user';
-
 import fetchApi from 'api/fetch';
+import useModalHandler from './useModalHandler';
+import { ModalHandler } from 'types/common';
 
 const useResetProfile = () => {
   const resetProfile = useResetRecoilState(profileState);
   const setProfileData = useSetRecoilState(profileState);
-  const [modalState, setModalState] = useRecoilState(modalStateStore);
+  const handleModal = useModalHandler();
 
   const resetProfileData = async (userName: string) => {
     resetProfile();
-    setModalState({
-      ...modalState,
-      editProfile: false,
-      post: { ...modalState.post, writer: false }
-    });
+    handleModal(ModalHandler.CLOSE_ALL);
     const { data: fetchProfileData, error } = await fetchApi.getProfile(userName);
     if (!error) setProfileData(fetchProfileData);
   };

--- a/client/src/pages/GroupPage.tsx
+++ b/client/src/pages/GroupPage.tsx
@@ -5,8 +5,8 @@ import { useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil';
 
 import { currentPageStates } from 'recoil/common';
 import { groupState } from 'recoil/group';
-
-import { Page } from 'types/common';
+import useModalHandler from 'hooks/useModalHandler';
+import { ModalHandler, Page } from 'types/common';
 import { defaultGroup } from 'images/groupimg';
 
 import { InitUserData, LoadingModal, FakeSideBar, FakeGnb } from 'components/common';
@@ -56,10 +56,14 @@ const GroupPage: React.FC<RouteComponentProps<{ groupidx: string }>> = ({ match 
   const groupData = useRecoilValue(groupState);
   const resetGroupData = useResetRecoilState(groupState);
   const setCurrentPage = useSetRecoilState(currentPageStates);
+  const handleModal = useModalHandler();
 
   useEffect(() => {
     setCurrentPage(Page.GROUP);
-    return () => resetGroupData();
+    return () => {
+      handleModal(ModalHandler.CLOSE_ALL);
+      resetGroupData();
+    };
   }, []);
 
   return (

--- a/client/src/pages/GroupSelectPage.tsx
+++ b/client/src/pages/GroupSelectPage.tsx
@@ -3,8 +3,8 @@ import styled, { createGlobalStyle, css } from 'styled-components';
 import { useSetRecoilState } from 'recoil';
 
 import { currentPageStates } from 'recoil/common';
-
-import { Page } from 'types/common';
+import useModalHandler from 'hooks/useModalHandler';
+import { ModalHandler, Page } from 'types/common';
 
 import { FakeSideBar, InitUserData, FakeGnb } from 'components/common';
 import { GroupSelectTitle, GroupSelectList } from 'components/GroupSelectPage';
@@ -45,9 +45,11 @@ const ContentsContainer = styled.div`
 
 const GroupSelectPage = () => {
   const setCurrentPage = useSetRecoilState(currentPageStates);
+  const handleModal = useModalHandler();
 
   useEffect(() => {
     setCurrentPage(Page.GROUP_SELECT);
+    return () => handleModal(ModalHandler.CLOSE_ALL);
   }, []);
 
   return (

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -1,11 +1,11 @@
 import { useEffect } from 'react';
 import styled, { createGlobalStyle, css } from 'styled-components';
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { currentPageStates } from 'recoil/common';
 import { imageViewerState as ivState } from 'recoil/post';
-
-import { Page } from 'types/common';
+import { ModalHandler, Page } from 'types/common';
+import useModalHandler from 'hooks/useModalHandler';
 
 import { PostWriter, PostList, ImageViewer } from 'components/HomePage';
 import { FakeSideBar, InitUserData, FakeGnb } from 'components/common';
@@ -50,13 +50,15 @@ const InnerContainer = styled.div`
 `;
 
 const HomePage = () => {
-  const [imageViewerState, setImageViewerState] = useRecoilState(ivState);
+  const imageViewerState = useRecoilValue(ivState);
   const setCurrentPage = useSetRecoilState(currentPageStates);
+  const handleModal = useModalHandler();
 
   useEffect(() => {
     setCurrentPage(Page.HOME);
 
     return () => {
+      handleModal(ModalHandler.CLOSE_ALL);
       window.scrollTo({ top: 0 });
     };
   }, []);

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -6,8 +6,8 @@ import { useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil';
 import { currentPageStates } from 'recoil/common';
 import { userDataStates, profileState } from 'recoil/user';
 import { imageViewerState } from 'recoil/post';
-
-import { Page } from 'types/common';
+import useModalHandler from 'hooks/useModalHandler';
+import { ModalHandler, Page } from 'types/common';
 
 import { InitUserData, LoadingModal, FakeSideBar, FakeGnb, FakeProfileBar } from 'components/common';
 import { PostWriter, ImageViewer } from 'components/HomePage';
@@ -73,6 +73,7 @@ const ProfilePage: React.FC<RouteComponentProps<{ username: string }>> = ({ matc
   const imageViewer = useRecoilValue(imageViewerState);
   const [myProfile, setMyProfile] = useState<boolean>(false);
   const setCurrentPage = useSetRecoilState(currentPageStates);
+  const handleModal = useModalHandler();
 
   useEffect(() => {
     if (userData.name === profileData.nickname) setMyProfile(true);
@@ -82,6 +83,7 @@ const ProfilePage: React.FC<RouteComponentProps<{ username: string }>> = ({ matc
   useEffect(() => {
     setCurrentPage(Page.PROFILE);
     return () => {
+      handleModal(ModalHandler.CLOSE_ALL);
       resetProfileData();
     };
   }, []);

--- a/client/src/recoil/common/index.tsx
+++ b/client/src/recoil/common/index.tsx
@@ -9,7 +9,6 @@ export const modalStateStore = atom({
     post: {
       writer: false,
       inPhoto: false,
-      index: -1,
       isEnroll: true
     },
     editProfile: false

--- a/client/src/types/common/index.tsx
+++ b/client/src/types/common/index.tsx
@@ -25,3 +25,18 @@ export enum Page {
   GROUP,
   PROFILE
 }
+
+export enum ModalHandler {
+  OPEN_POST_WRITER,
+  OPEN_IMAGE_UPLOADER,
+  OPEN_USER_SEARCH,
+  TOGGLE_EDIT_PROFILE,
+  TOGGLE_IMAGE_UPLOADER,
+  CLOSE_ALL
+}
+
+export interface ModalHandlerOptions {
+  post?: {
+    isEnroll?: boolean;
+  };
+}


### PR DESCRIPTION
## 개요
- 모달창이 열리고 닫힘에 따라 관련없는 컴포넌트도 리렌더링 되던 문제를 해결

## 작업사항
- 모달창 상태 관리를 위한 custom hook 제작
- 모달창 상태 관리를 위한 enum type 설정
- 각 게시물에 대한 수정/삭제 option modal visibility 관리 방식을 전역 상태 -> useState로 변경
- 게시글 최대 300개만 보일 수 있도록 수정
